### PR TITLE
pass hg's ui.ssh config to dulwich

### DIFF
--- a/hggit/git_handler.py
+++ b/hggit/git_handler.py
@@ -12,6 +12,7 @@ from mercurial.i18n import _
 from mercurial.node import hex, bin, nullid
 from mercurial import context, util as hgutil
 
+from hggit import ssh
 
 class GitHandler(object):
 
@@ -820,6 +821,10 @@ class GitHandler(object):
             return string.decode('ascii', 'replace').encode('utf-8')
 
     def get_transport_and_path(self, uri):
+        # pass hg's ui.ssh config to dulwich
+        if not issubclass(client.get_ssh_vendor, ssh.SSHVendor):
+            client.get_ssh_vendor = ssh.generate_ssh_vendor(self.ui)
+
         for handler, transport in (("git://", client.TCPGitClient),
                                    ("git@", client.SSHGitClient),
                                    ("git+ssh://", client.SSHGitClient)):

--- a/hggit/ssh.py
+++ b/hggit/ssh.py
@@ -1,0 +1,25 @@
+class SSHVendor(object):
+    """Parent class for ui-linked Vendor classes."""
+
+
+def generate_ssh_vendor(ui):
+    """
+    Allows dulwich to use hg's ui.ssh config. The dulwich.client.get_ssh_vendor
+    property should point to the return value.
+    """
+
+    class _Vendor(SSHVendor):
+        def connect_ssh(self, host, command, username=None, port=None):
+            from dulwich.client import SubprocessWrapper
+            from mercurial import util
+            import subprocess
+
+            sshcmd = ui.config("ui", "ssh", "ssh")
+            args = util.sshargs(sshcmd, host, username, port)
+
+            proc = subprocess.Popen([sshcmd, args] + command,
+                                    stdin=subprocess.PIPE,
+                                    stdout=subprocess.PIPE)
+            return SubprocessWrapper(proc)
+
+    return _Vendor


### PR DESCRIPTION
Mostly useful for Windows users, who need to use something other than `ssh.exe` - usually, putty's `plink.exe`.

(You may encounter a merge conflict; the [resolution](https://github.com/rctay/hg-git/commit/e00c08af7b7fee65297c68f0d7aaa94ebda1efef) is fairly trivial.)
