### PR TITLE
Don't die if a tag ref doesn't map to a git commit. Fixes issue #198.

### DIFF
--- a/hggit/git_handler.py
+++ b/hggit/git_handler.py
@@ -683,8 +683,13 @@ class GitHandler(object):
         for tag, sha in self.repo.tags().iteritems():
             if self.repo.tagtype(tag) in ('global', 'git'):
                 tag = tag.replace(' ', '_')
-                self.git.refs['refs/tags/' + tag] = self.map_git_get(hex(sha))
-                self.tags[tag] = hex(sha)
+                sha_hex = hex(sha)
+                tag_ref = self.map_git_get(sha_hex)
+                if not tag_ref:
+                    self.ui.status(_("WARNING: no ref for hg SHA " + sha_hex + "\n"))
+                else:
+                    self.git.refs['refs/tags/' + tag] = tag_ref
+                    self.tags[tag] = sha_hex
 
     def local_heads(self):
         try:


### PR DESCRIPTION
Not sure if this is entirely the correct fix — I don't know where that ref is coming from — but not bombing out sure works better for me.

This is reproducible in a clone of http://hg.mozilla.org/mozilla-central , if you're willing to wait about a week for hg-git to finish running (and have about 14GB of RAM).
