### PR TITLE
none@none instead of email when author is just an email

### DIFF
--- a/hggit/git_handler.py
+++ b/hggit/git_handler.py
@@ -286,6 +286,8 @@ class GitHandler(object):
             if len(a.group(3)) > 0:
                 name += ' ext:(' + urllib.quote(a.group(3)) + ')'
             author = name + ' <' + email + '>'
+        elif '@' in author:
+            author = author + ' <' + author + '>'
         else:
             author = author + ' <none@none>'
 


### PR DESCRIPTION
When the author is just an email then use "email &lt;email&gt;" as author.
