### PR TITLE
Fix for issue #213 [hg outgoing fails on empty repository]

### DIFF
--- a/hggit/git_handler.py
+++ b/hggit/git_handler.py
@@ -200,8 +200,11 @@ class GitHandler(object):
             changed_refs = [ref for ref, sha in new_refs.iteritems()
                             if sha != old_refs.get(ref)]
             new = [bin(self.map_hg_get(new_refs[ref])) for ref in changed_refs]
-            old = dict( (bin(self.map_hg_get(old_refs[r])), 1)
-                       for r in old_refs)
+            old = {}
+            for r in old_refs:
+                old_ref = self.map_hg_get(old_refs[r])
+                if old_ref:
+                    old[bin(old_ref)] = 1
 
             return old, new
         except (HangupException, GitProtocolError), e:
@@ -809,7 +812,9 @@ class GitHandler(object):
         # Create a local Git branch name for each
         # Mercurial bookmark.
         for key in heads:
-            self.git.refs['refs/heads/' + key] = self.map_git_get(heads[key])
+            git_ref = self.map_git_get(heads[key])
+            if git_ref:
+                self.git.refs['refs/heads/' + key] = self.map_git_get(heads[key])
 
     def export_hg_tags(self):
         for tag, sha in self.repo.tags().iteritems():


### PR DESCRIPTION
"In some situations where a reference is being used but does not exist in _map_git or _map_hg, silently skip the reference rather than throwing an error. This allows hg outgoing to work on repositories which do not contain any revisions at all."

This patch is very short, but I am not sure I went about implementing the fix the right way so I am going to overexplain what I did.

---

I was trying to address https://github.com/schacon/hg-git/issues/213

I did some testing on 2 repos exhibiting this problem but which gave different error messages. I used mercurial 1.8.4, dulwich [newest] and top of tree hg-git.

The first one I tried was git+ssh://git@github.com:mcclure/hg-git.git
(I made a fork of the hg-git repository, but it contained no commits yet).

This one got the "TypeError: a2b_hex() argument 1 must be string or read-only buffer, not None" error. (See the pastie on issue 213).

The problem turned out to be occurring because map_hg_get in git_handler.py was returning None for a particular value in old_refs when called in get_refs on this line:

```
        old = dict( (bin(self.map_hg_get(old_refs[r])), 1)
                   for r in old_refs)
```

This happened because one of the keys in old_refs: 

'.have': '0c865452c0a6cfd26e4b61ff5d49136665530caf

Did not exist in _map_git (and in fact didn't exist in "mapfile").

---

The second error saw the "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'" symptom. In this case the repo was git+ssh://git@github.com:mcclure/empty.git
(This is a repository I made on github and have never committed to)

In this case, the failure was occurring in update_references in git_handler.py, on the line 

```
        self.git.refs['refs/heads/' + key] = self.map_git_get(heads[key])
```

In this case, "key" was equal to "MASTER", heads[key] was equal to 0000000000000000000000000000000000000000, and self.map_git_get(heads[key]) was equal to None. map_git_get did this because _map_hg was actually empty. This meant None was being passed in to the self.git.refs setitem, causing a crash.

---

My fix in both cases was to check for "None" and, if None, ignore that particular commit rather than attempting to do the operation which threw the error (bin() or refs[]=). After making this change, both repositories would perform correctly (printing "no changes" or the appropriate change list as... appropriate).

My questions:
- Is this an okay fix? The problem is that I seem to be addressing a very specific problem [when repository is empty, various things seem to be spitting out "magic" values, like 0000, that are not in the _map_\* dictionaries, and hggit doesn't have special case behavior for this] with a very general fix [always tolerate the use of values which are not in the _map_\* dictionaries]. This worries me because it might not solve the "real" problem (although it produces the correct behavior) and might mask bugs in future (say if there is something which is not in a _map_\* dictionary, but really ought to be).
- What is ".have"? hggit prints out messages about ".have" all the time. Is it something magic?
