### PR TITLE
only want heads and tags

### DIFF
--- a/hggit/git_handler.py
+++ b/hggit/git_handler.py
@@ -785,7 +785,8 @@ class GitHandler(object):
                         raise hgutil.Abort("ambiguous reference %s: %r" % (h, r))
             else:
                 want = [sha for ref, sha in refs.iteritems()
-                        if not ref.endswith('^{}')]
+                        if not ref.endswith('^{}')
+                        and ( ref.startswith('refs/heads/') or ref.startswith('refs/tags/') ) ]
             want = [x for x in want if x not in self.git]
             return want
         f, commit = self.git.object_store.add_pack()


### PR DESCRIPTION
i didn't test this, since i don't have a test env setup, but something like this will fix stuff like #219 #217

we should only be wanting and converting refs in the heads/ and tags/ spaces, since that's all we deal with after the fact.  anything else will just show up as weird unreferenced heads.
