### PR TITLE
Improve hg-git's author/committer parsing to match what git expects

### DIFF
--- a/hggit/git_handler.py
+++ b/hggit/git_handler.py
@@ -345,7 +345,7 @@ class GitHandler(object):
         author = ctx.user()
 
         # check for git author pattern compliance
-        regex = re.compile('^(.*?) ?\<(.*?)\>(.*)$')
+        regex = re.compile('^(.*?) ?\<(.*?)\>?(.*)$')
         a = regex.match(author)
 
         if a:


### PR DESCRIPTION
I found out about this problem when converting Mozilla's hg repository to git.

The way that git parses the author/commiter lines is that it looks for the first less-than character, and expects that to start the email address, and then it looks for the next greater-than character, and it then expects everything following that character to be parsed as a date.

hg-git's output doesn't completely match that expectation.  For example, for this revision hg.mozilla.org/mozilla-central/rev/a537a070dbf40081e1d32321924b6589b271574e, the author is "Ms2ger@gmail.com", which makes hg-git generate a author line like this:

author Ms2ger@gmail.com none@none 123456000 +0000

Which git fails to parse.  Another example is this revision http://hg.mozilla.org/mozilla-central/rev/e88d2327e25d600ce326615f682db1d79d2bb10e, where there is no space between the username and the email, which creates an author line like this:

author Ms2ger<Ms2ger@gmail.com <Ms2ger<Ms2ger@gmail.com> 123456000 +0000

And you can see how that would confuse git!

With the fixes in this pull request, hg-git can generate better commit objects, that git can actually deal with.  I managed to convert the entire hg history of mozilla-central to git with these patches.
