### PR TITLE
README: add URLs of homepage, primary hg repo, and git mirror repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Hg-Git Mercurial Plugin
 =======================
 
+* Homepage: http://hg-git.github.com/
+* https://bitbucket.org/durin42/hg-git (primary)
+* https://github.com/schacon/hg-git (mirror)
+
 This is the Hg-Git plugin for Mercurial, adding the ability to push
 and pull to/from a Git server repository from Hg.  This means you can
 collaborate on Git based projects from Hg, or use a Git server as a


### PR DESCRIPTION
This makes it easier to discover, from the git repo, that the primary repository is actually in hg, and to find the project's new home page. Thanks!
