### PR TITLE
Paths without protocol probably is an local directory

### DIFF
--- a/hggit/git_handler.py
+++ b/hggit/git_handler.py
@@ -1602,4 +1602,4 @@ class GitHandler(object):
                     raise
 
         # if its not git or git+ssh, try a local url..
-        return client.SubprocessGitClient(), uri
+        return client.LocalGitClient(), uri


### PR DESCRIPTION
It might be that I don't understand which default case the SubprocessGitClient should cover. This path helped me to push to a git repository in a local directory.