### PR TITLE
ssh: fix arg issue with dulwich 0.12.x

### DIFF
--- a/hggit/_ssh.py
+++ b/hggit/_ssh.py
@@ -14,15 +14,10 @@ def generate_ssh_vendor(ui):
 
     class _Vendor(SSHVendor):
         def run_command(self, host, command, username=None, port=None):
-            # newer dulwich changes the way they pass command and parameters
-            # around, so we detect that here and reformat it back to what
-            # hg-git expects (e.g. "command 'arg1 arg2'")
-            if len(command) > 1:
-                command = ["%s '%s'" % (command[0], ' '.join(command[1:]))]
             sshcmd = ui.config("ui", "ssh", "ssh")
             args = util.sshargs(sshcmd, host, username, port)
             cmd = '%s %s %s' % (sshcmd, args,
-                                util.shellquote(' '.join(command)))
+                                util.shellquote(''.join(command)))
             ui.debug('calling ssh: %s\n' % cmd)
             proc = subprocess.Popen(util.quotecommand(cmd), shell=True,
                                     stdin=subprocess.PIPE,


### PR DESCRIPTION
It appears commit 032079b1 introduced a method to structure arguments in
such a way to be compatible with dulwich 0.11.x.  This however breaks in
0.12.x versions.  Reverting the above commit and restructuring the join
in the git command passed to ssh.

Currently this results in:
$ hg --debug -v clone git+ssh://machine.domain.org/code/conf conf
calling ssh: ssh machine.domain.org 'g '\''i t - u p l o a d - p a c k   '\'' / c o d e / c o n f '\'''\'''
Warning: Permanently added '[machine.domain.org]:22,[10.10.10.10]:22' (ECDSA) to the list of known hosts.
bash: g: command not found
abort: git remote error: The remote server unexpectedly closed the connection.

After reverting:
$ hg --debug -v clone git+ssh://machine.domain.org/code/conf conf
calling ssh: ssh machine.domain.org 'git-upload-pack '\''/code/conf'\'''
Warning: Permanently added '[machine.domain.org]:22,[10.10.10.10]:22' (ECDSA) to the list of known hosts.
Counting objects: 3905, done.
...
